### PR TITLE
fix：更新策略以及追蹤清單會重複呼叫

### DIFF
--- a/public/js/Bootstrap.js
+++ b/public/js/Bootstrap.js
@@ -125,8 +125,11 @@ function handleDrop(e) {
 // 拖動結束
 function handleDragEnd(e) {
   draggedItem = null;
-  updateListOrderOnServer();
-  updateStrategyOrderOnServer();
+  if (this.classList.contains("strategy-item")) {
+    updateStrategyOrderOnServer(); // 更新策略順序
+  } else if (this.closest("#favoritesList")) {
+    updateListOrderOnServer(); // 更新追蹤清單順序
+  }
 }
 
 // 更新追蹤清單順序


### PR DESCRIPTION
- 問題：更新策略以及追蹤清單會重複呼叫 - 原因：沒有判斷目前是在哪個元素作用 - 解決方式：依據元素作判斷